### PR TITLE
Apply fixes to 1.30.2 version

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -826,6 +826,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `record-duplicated-events` | Enable the autoscaler to print duplicated events within a 5 minute window. | false
 | `debugging-snapshot-enabled` | Whether the debugging snapshot of cluster autoscaler feature is enabled. | false
 | `node-delete-delay-after-taint` | How long to wait before deleting a node after tainting it. | 5 seconds
+| `external-node-deletion` | If true, CA will not adjust replica counts to delete failed nodes, deletion is delegated to the cloud provider. | false
 
 # Troubleshooting:
 

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -120,6 +120,13 @@ func (asg *Asg) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *Asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := asg.manager.GetAsgSize(asg)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -323,6 +323,13 @@ func (ng *AwsNodeGroup) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *AwsNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	size := ng.asg.curSize

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -427,6 +427,13 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (as *AgentPool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -485,6 +485,13 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 	return nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (scaleSet *ScaleSet) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -283,6 +283,13 @@ func (asg *Asg) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *Asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -105,6 +105,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
@@ -128,6 +128,13 @@ func (ng *brightboxNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *brightboxNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned
 // either on failure or if the given node doesn't belong to this
 // node group. This function should wait until node group size is

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
@@ -118,6 +118,13 @@ func (ng *cherryNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *cherryNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes a set of nodes chosen by the autoscaler.
 func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	// Batch simultaneous deletes on individual nodes

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -123,6 +123,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -193,7 +193,14 @@ type NodeGroup interface {
 	// are provisioned atomically.
 	AtomicIncreaseSize(delta int) error
 
-	// DeleteNodes deletes nodes from this node group. Error is returned either on
+	// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+	// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+	// Error is returned either on failure or if the given node doesn't belong to this node group.
+	// Implementation required.
+	MarkNodesForDeletion([]*apiv1.Node) error
+
+	// DeleteNodes deletes nodes from this node group and shrinks the node
+	// group target size by the number of deleted nodes. Error is returned either on
 	// failure or if the given node doesn't belong to this node group. This function
 	// should wait until node group size is updated. Implementation required.
 	DeleteNodes([]*apiv1.Node) error

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -98,6 +98,13 @@ func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 	return false, fmt.Errorf("Unable to find node %s in cluster", node.Name)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *asg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
 	if asg.cluster.WorkerCount-len(nodes) < asg.MinSize() {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -94,6 +94,46 @@ func (ng *nodegroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned on failure.
+func (ng *nodegroup) MarkNodesForDeletion(nodes []*corev1.Node) error {
+	ng.machineController.accessLock.Lock()
+	defer ng.machineController.accessLock.Unlock()
+
+	// Annotate the corresponding machine that it is a suitable candidate for deletion.
+	// Fail fast on any error.
+	for _, node := range nodes {
+		machine, err := ng.machineController.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))
+		if err != nil {
+			return err
+		}
+		if machine == nil {
+			return fmt.Errorf("unknown machine for node %q", node.Spec.ProviderID)
+		}
+
+		machine = machine.DeepCopy()
+
+		if !machine.GetDeletionTimestamp().IsZero() {
+			// The machine for this node is already being deleted
+			continue
+		}
+
+		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
+		if err != nil {
+			return err
+		}
+
+		klog.V(4).Infof("Marking machine for deletion: %v", machine.GetName())
+
+		if err := nodeGroup.scalableResource.MarkMachineForImmediateDeletion(machine); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned
 // either on failure or if the given node doesn't belong to this node
 // group. This function should wait until node group size is updated.
@@ -107,7 +147,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		return err
 	}
 
-	// if we are at minSize already we wail early.
+	// if we are at minSize already we fail early.
 	if replicas <= ng.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
@@ -159,7 +199,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 			return err
 		}
 
-		if err := nodeGroup.scalableResource.MarkMachineForDeletion(machine); err != nil {
+		if err := nodeGroup.scalableResource.MarkMachineForPreferredDeletion(machine); err != nil {
 			return err
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -150,7 +150,15 @@ func (r unstructuredScalableResource) UnmarkMachineForDeletion(machine *unstruct
 	return updateErr
 }
 
-func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructured.Unstructured) error {
+func (r unstructuredScalableResource) MarkMachineForPreferredDeletion(machine *unstructured.Unstructured) error {
+	return r.AnnotateMachine(machine, machineDeleteAnnotationKey, time.Now().String())
+}
+
+func (r unstructuredScalableResource) MarkMachineForImmediateDeletion(machine *unstructured.Unstructured) error {
+	return r.AnnotateMachine(machine, markMachineForDeleteAnnotationKey, time.Now().String())
+}
+
+func (r unstructuredScalableResource) AnnotateMachine(machine *unstructured.Unstructured, key string, value string) error {
 	u, err := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(machine.GetNamespace()).Get(context.TODO(), machine.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -163,7 +171,7 @@ func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructur
 		annotations = map[string]string{}
 	}
 
-	annotations[machineDeleteAnnotationKey] = time.Now().String()
+	annotations[key] = value
 	u.SetAnnotations(annotations)
 
 	_, updateErr := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(u.GetNamespace()).Update(context.TODO(), u, metav1.UpdateOptions{})

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -81,9 +81,14 @@ var (
 	errInvalidMaxAnnotation = errors.New("invalid max annotation")
 
 	// machineDeleteAnnotationKey is the annotation used by cluster-api to indicate
-	// that a machine should be deleted. Because this key can be affected by the
+	// that a machine should be preferred for deletion. Because this key can be affected by the
 	// CAPI_GROUP env variable, it is initialized here.
 	machineDeleteAnnotationKey = getMachineDeleteAnnotationKey()
+
+	// markMachineForDelete is the annotation used by cluster-api to indicate
+	// that a machine should be deleted ASAP. Because this key can be affected by the
+	// CAPI_GROUP env variable, it is initialized here.
+	markMachineForDeleteAnnotationKey = getMarkMachineForDeleteAnnotationKey()
 
 	// machineAnnotationKey is the annotation used by the cluster-api on Node objects
 	// to specify the name of the related Machine object. Because this can be affected
@@ -293,10 +298,21 @@ func getNodeGroupMaxSizeAnnotationKey() string {
 }
 
 // getMachineDeleteAnnotationKey returns the key that is used by cluster-api for marking
-// machines to be deleted. This function is needed because the user can change the default
+// machines to be preferred for deletion during scaling events.
+// This function is needed because the user can change the default
 // group name by using the CAPI_GROUP environment variable.
 func getMachineDeleteAnnotationKey() string {
 	key := fmt.Sprintf("%s/delete-machine", getCAPIGroup())
+	return key
+}
+
+// getMarkMachineForDeleteAnnotationKey returns the key that is used by cluster-api for marking
+// machines to be deleted as soon as possible by cluster-api without a scaling event occurring.
+// This function is needed because the user can change the default group name by using the CAPI_GROUP
+// environment variable. A new annotation was needed to avoid breaking compatibility with the existing
+// delete-machine annotation that only marks nodes as "preferred" for deletion during scaling events.
+func getMarkMachineForDeleteAnnotationKey() string {
+	key := fmt.Sprintf("%s/machine-marked-for-delete", getCAPIGroup())
 	return key
 }
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -845,6 +845,11 @@ func Test_getKeyHelpers(t *testing.T) {
 			testfunc: getMachineDeleteAnnotationKey,
 		},
 		{
+			name:     "test group, mark machine for delete annotation key",
+			expected: fmt.Sprintf("%s/machine-marked-for-delete", testgroup),
+			testfunc: getMarkMachineForDeleteAnnotationKey,
+		},
+		{
 			name:     "test group, machine annotation key",
 			expected: fmt.Sprintf("%s/machine", testgroup),
 			testfunc: getMachineAnnotationKey,

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -111,6 +111,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
@@ -102,6 +102,13 @@ func (ng *equinixMetalNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *equinixMetalNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
 //
 // The process of deletion depends on the implementation of equinixMetalManager,

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -98,6 +98,13 @@ func (n *instancePoolNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *instancePoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -97,6 +97,13 @@ func (n *sksNodepoolNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *sksNodepoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -99,6 +99,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -283,6 +283,13 @@ func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (mig *gceMig) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := mig.gceManager.GetMigSize(mig)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -159,6 +159,13 @@ func (n *hetznerNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *hetznerNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -99,6 +99,13 @@ func (asg *AutoScalingGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *AutoScalingGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -87,6 +87,13 @@ func (n *nodePool) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *nodePool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also decreasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
@@ -19,6 +19,9 @@ package kamatera
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strconv"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface. NodeGroup contains
@@ -86,6 +87,13 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 
 // AtomicIncreaseSize is not implemented.
 func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -221,6 +221,13 @@ func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return instances, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (nodeGroup *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the specified nodes from the node group.
 func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := nodeGroup.kubemarkController.GetNodeGroupTargetSize(nodeGroup.Name)

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
@@ -92,6 +92,13 @@ func (nodeGroup *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (nodeGroup *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the specified nodes from the node group.
 func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	size := nodeGroup.targetSize

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
@@ -103,6 +103,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -93,6 +93,13 @@ func (ng *magnumNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *magnumNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
 func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	ng.clusterUpdateLock.Lock()

--- a/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
+++ b/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
@@ -111,6 +111,20 @@ func (_m *NodeGroup) Delete() error {
 	return r0
 }
 
+// MarkNodesForDeletion provides a mock function with given fields: _a0
+func (_m *NodeGroup) MarkNodesForDeletion(_a0 []*v1.Node) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]*v1.Node) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteNodes provides a mock function with given fields: _a0
 func (_m *NodeGroup) DeleteNodes(_a0 []*v1.Node) error {
 	ret := _m.Called(_a0)

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -6,6 +6,7 @@ package instancepools
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -66,6 +67,13 @@ func (ip *InstancePoolNodeGroup) IncreaseSize(delta int) error {
 
 // AtomicIncreaseSize is not implemented.
 func (ip *InstancePoolNodeGroup) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ip *InstancePoolNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -113,6 +113,13 @@ func (np *nodePool) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (np *nodePool) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -116,6 +116,13 @@ func (ng *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	// DeleteNodes is called in goroutine so it can run in parallel

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -105,6 +105,13 @@ func (ng *nodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return instances, nil
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *nodeGroup) MarkNodesForDeletion(nodes []*corev1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the specified nodes from the node group.
 func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
 	if ng.replicas-len(toDelete) < ng.MinSize() {

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface.
@@ -103,6 +104,13 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 
 // AtomicIncreaseSize is not implemented.
 func (ng *NodeGroup) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (ng *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
@@ -201,6 +201,13 @@ func (asg *tcAsg) Autoprovisioned() bool {
 	return false
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *tcAsg) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes the nodes from the group.
 func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
 	size, err := asg.tencentcloudManager.GetAsgSize(asg)

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -444,6 +444,13 @@ func (tng *TestNodeGroup) DecreaseTargetSize(delta int) error {
 	return tng.cloudProvider.onScaleUp(tng.id, delta)
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (tng *TestNodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
@@ -74,6 +74,13 @@ func (asg *AutoScalingGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (asg *AutoScalingGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
@@ -101,6 +101,13 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+// MarkNodesForDeletion notifies the cloud provider that the provided nodes need to be deleted.
+// The cloud provider is expected to handle deletion of the marked nodes gracefully.
+// Error is returned either on failure or if the given node doesn't belong to this node group.
+func (n *NodeGroup) MarkNodesForDeletion(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DeleteNodes deletes nodes from this node group (and also increasing the size
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -282,6 +282,8 @@ type AutoscalingOptions struct {
 	ParallelDrain bool
 	// NodeGroupSetRatio is a collection of ratios used by CA used to make scaling decisions.
 	NodeGroupSetRatios NodeGroupDifferenceRatios
+	// ExternalNodeDeletion controls whether or not CA will adjust replica counts to delete failed nodes. If true, replica counts are only modifed for scale up/down events and responsibility for the deletion of failed nodes is delegated to the cloud provider.
+	ExternalNodeDeletion bool
 	// dynamicNodeDeleteDelayAfterTaintEnabled is used to enable/disable dynamic adjustment of NodeDeleteDelayAfterTaint
 	// based on the latency between the CA and the api-server
 	DynamicNodeDeleteDelayAfterTaintEnabled bool

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -808,7 +808,14 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clu
 			nodesToDelete = instancesToFakeNodes(instances)
 		}
 
-		err = nodeGroup.DeleteNodes(nodesToDelete)
+		if a.AutoscalingContext.AutoscalingOptions.ExternalNodeDeletion {
+			// allow the cloud provider to handle node deletion instead of deleting nodes through downscaling replica counts
+			fmt.Printf("MarkNodesForDeletion (removeOldUnregisteredNodes)\n")
+			err = nodeGroup.MarkNodesForDeletion(nodesToDelete)
+		} else {
+			fmt.Printf("DeleteNodes (removeOldUnregisteredNodes)\n")
+			err = nodeGroup.DeleteNodes(nodesToDelete)
+		}
 		csr.InvalidateNodeInstancesCacheEntry(nodeGroup)
 		if err != nil {
 			klog.Warningf("Failed to remove %v unregistered nodes from node group %s: %v", len(nodesToDelete), nodeGroupId, err)
@@ -887,7 +894,14 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 				}
 				nodesToBeDeleted = instancesToFakeNodes(instances)
 			}
-			err = nodeGroup.DeleteNodes(nodesToBeDeleted)
+			if a.AutoscalingContext.AutoscalingOptions.ExternalNodeDeletion {
+				// allow the cloud provider to handle node deletion instead of deleting nodes through downscaling replica counts
+				fmt.Printf("MarkNodesForDeletion (deleteCreatedNodesWithErrors)\n")
+				err = nodeGroup.MarkNodesForDeletion(nodesToBeDeleted)
+			} else {
+				fmt.Printf("DeleteNodes (deleteCreatedNodesWithErrors)\n")
+				err = nodeGroup.DeleteNodes(nodesToBeDeleted)
+			}
 		}
 
 		if err != nil {

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -35,15 +35,16 @@ type FakeNodeGroup struct {
 	id string
 }
 
-func (f *FakeNodeGroup) MaxSize() int                       { return 2 }
-func (f *FakeNodeGroup) MinSize() int                       { return 1 }
-func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
-func (f *FakeNodeGroup) AtomicIncreaseSize(delta int) error { return cloudprovider.ErrNotImplemented }
-func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
-func (f *FakeNodeGroup) Id() string                         { return f.id }
-func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) MaxSize() int                             { return 2 }
+func (f *FakeNodeGroup) MinSize() int                             { return 1 }
+func (f *FakeNodeGroup) TargetSize() (int, error)                 { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error             { return nil }
+func (f *FakeNodeGroup) AtomicIncreaseSize(delta int) error       { return cloudprovider.ErrNotImplemented }
+func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error       { return nil }
+func (f *FakeNodeGroup) MarkNodesForDeletion([]*apiv1.Node) error { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error          { return nil }
+func (f *FakeNodeGroup) Id() string                               { return f.id }
+func (f *FakeNodeGroup) Debug() string                            { return f.id }
 func (f *FakeNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return []cloudprovider.Instance{}, nil
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -253,6 +253,7 @@ var (
 	maxFreeDifferenceRatio                  = flag.Float64("max-free-difference-ratio", config.DefaultMaxFreeDifferenceRatio, "Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource.")
 	maxAllocatableDifferenceRatio           = flag.Float64("max-allocatable-difference-ratio", config.DefaultMaxAllocatableDifferenceRatio, "Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource.")
 	forceDaemonSets                         = flag.Bool("force-ds", false, "Blocks scale-up of node groups too small for all suitable Daemon Sets pods.")
+	externalNodeDeletion                    = flag.Bool("external-node-deletion", false, "If true, CA will not adjust replica counts to delete failed nodes, deletion is delegated to the cloud provider.")
 	dynamicNodeDeleteDelayAfterTaintEnabled = flag.Bool("dynamic-node-delete-delay-after-taint-enabled", false, "Enables dynamic adjustment of NodeDeleteDelayAfterTaint based of the latency between CA and api-server")
 	bypassedSchedulers                      = pflag.StringSlice("bypassed-scheduler-names", []string{}, fmt.Sprintf("Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up."))
 	drainPriorityConfig                     = flag.String("drain-priority-config", "",
@@ -432,6 +433,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 			MaxAllocatableDifferenceRatio:    *maxAllocatableDifferenceRatio,
 			MaxFreeDifferenceRatio:           *maxFreeDifferenceRatio,
 		},
+		ExternalNodeDeletion:                    *externalNodeDeletion,
 		DynamicNodeDeleteDelayAfterTaintEnabled: *dynamicNodeDeleteDelayAfterTaintEnabled,
 		BypassedSchedulers:                      scheduler_util.GetBypassedSchedulersMap(*bypassedSchedulers),
 		ProvisioningRequestEnabled:              *provisioningRequestsEnabled,


### PR DESCRIPTION
Apply the 2 fixes below on top of [cluster-autoscaler-1.30.2](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.30.2/) upstream git tag.

- https://github.com/kubernetes/autoscaler/commit/3f02b7016f900ae1117b3def348880dd7a7fe626
- https://github.com/kubernetes/autoscaler/commit/b93a6aa695f20f6e2f2ad5f41e931ab8c12ffd1f

The base branch `1.30.2-external-node-deletion` was created from [cluster-autoscaler-1.30.2](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.30.2/) upstream git tag.

Relevant change: in CA 1.30.2 there's a new implementation of [GetKubeConfig](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.30.2/cluster-autoscaler/utils/kubernetes/client.go#L42) and [CreateKubeClient](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.30.2/cluster-autoscaler/utils/kubernetes/client.go#L37C6-L37C22) that had to be patched to apply the latter fix.